### PR TITLE
Safer escapes in removeFromHosts

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -80,7 +80,7 @@ module VagrantPlugins
       def removeFromHosts(options = {})
         hosts_path = '/etc/hosts'
         uuid = @machine.id
-        %Q(sed -e '/#{uuid}/ d' -ibak #{hosts_path})
+        %Q(sed -e '\\:#{uuid}:d' -ibak #{hosts_path})
       end
 
 


### PR DESCRIPTION
On VMware, the machine ID is not a GUID like with VirtualBox, but the full path to the `.vmx` file (e.g. `/Users/dzuelke/.../blah.vmx`). The `sed` call to remove `/etc/hosts` entries then fails due to syntax errors.

This change fixes the `sed` call by using a colon as the delimiter, and by escaping that delimiter (if that's not done, then it'll interpret ":" as the command due to the leading slash from the path).

Tested with VMware Fusion, and of course verified that nothing breaks with VirtualBox either :)
