### PR TITLE
Fixes #5 - Only remove hosts entry when VM is destroyed

### DIFF
--- a/lib/vagrant-hostsupdater/Action/CacheHosts.rb
+++ b/lib/vagrant-hostsupdater/Action/CacheHosts.rb
@@ -1,0 +1,20 @@
+module VagrantPlugins
+  module HostsUpdater
+    module Action
+      class CacheHosts
+        include HostsUpdater
+
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+        end
+
+        def call(env)
+          cacheHostEntries
+          @app.call(env)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-hostsupdater/Action/RemoveHosts.rb
+++ b/lib/vagrant-hostsupdater/Action/RemoveHosts.rb
@@ -12,11 +12,13 @@ module VagrantPlugins
 
         def call(env)
           machine_action = env[:machine_action]
-          if machine_action != :suspend || @machine.config.hostsupdater.remove_on_suspend
-            @ui.info "Removing hosts"
-            removeHostEntries
-          else
-            @ui.info "Removing hosts on suspend disabled"
+          if machine_action != :destroy || !@machine.id
+            if machine_action != :suspend || @machine.config.hostsupdater.remove_on_suspend
+              @ui.info "Removing hosts"
+              removeHostEntries
+            else
+              @ui.info "Removing hosts on suspend disabled"
+            end
           end
           @app.call(env)
         end

--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -42,14 +42,18 @@ module VagrantPlugins
         addToHosts(entries)
       end
 
+      def cacheHostEntries
+        @machine.config.hostsupdater.id = @machine.id
+      end
+
       def removeHostEntries
-        if !@machine.id
+        if !@machine.id and !@machine.config.hostsupdater.id
           @ui.warn "No machine id, nothing removed from #@@hosts_path"
           return
         end
         file = File.open(@@hosts_path, "rb")
         hostsContents = file.read
-        uuid = @machine.id
+        uuid = @machine.id || @machine.config.hostsupdater.id
         hashedId = Digest::MD5.hexdigest(uuid)
         if hostsContents.match(/#{hashedId}/)
             removeFromHosts
@@ -83,7 +87,7 @@ module VagrantPlugins
       end
 
       def removeFromHosts(options = {})
-        uuid = @machine.id
+        uuid = @machine.id || @machine.config.hostsupdater.id
         hashedId = Digest::MD5.hexdigest(uuid)
         if !File.writable?(@@hosts_path)
           sudo(%Q(sed -i -e '/#{hashedId}/ d' #@@hosts_path))

--- a/lib/vagrant-hostsupdater/config.rb
+++ b/lib/vagrant-hostsupdater/config.rb
@@ -4,6 +4,7 @@ module VagrantPlugins
   module HostsUpdater
     class Config < Vagrant.plugin("2", :config)
         attr_accessor :aliases
+        attr_accessor :id
         attr_accessor :remove_on_suspend
     end
   end

--- a/lib/vagrant-hostsupdater/plugin.rb
+++ b/lib/vagrant-hostsupdater/plugin.rb
@@ -1,4 +1,5 @@
 require "vagrant-hostsupdater/Action/UpdateHosts"
+require "vagrant-hostsupdater/Action/CacheHosts"
 require "vagrant-hostsupdater/Action/RemoveHosts"
 
 module VagrantPlugins
@@ -28,7 +29,11 @@ module VagrantPlugins
       end
 
       action_hook(:hostsupdater, :machine_action_destroy) do |hook|
-        hook.prepend(Action::RemoveHosts)
+        hook.prepend(Action::CacheHosts)
+      end
+
+      action_hook(:hostsupdater, :machine_action_destroy) do |hook|
+        hook.append(Action::RemoveHosts)
       end
 
       action_hook(:hostsupdater, :machine_action_reload) do |hook|


### PR DESCRIPTION
Only remove hosts if the destroy is confirmed, otherwise go away silently and hide in a corner and pretend nothing happened!

This fix is based on feedback from the vagrant team ([here](https://github.com/mitchellh/vagrant/issues/1878)).

Any feedback would be welcome :)
