### PR TITLE
Fix additional new lines being added to `hosts` file

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -74,16 +74,15 @@ module VagrantPlugins
 
       def addToHosts(entries)
         return if entries.length == 0
-        content = "\n" + entries.join("\n").strip
+        content = entries.join("\n").strip
         if !File.writable?(@@hosts_path)
           sudo(%Q(sh -c 'echo "#{content}" >> #@@hosts_path'))
         else
+          content = "\n" + content
           hostsFile = File.open(@@hosts_path, "a")
           hostsFile.write(content)
           hostsFile.close()
         end
-
-
       end
 
       def removeFromHosts(options = {})


### PR DESCRIPTION
Modify add to host behavior to prevent new line from being prepended when `echo`ing `content`.

It looks like the `echo` command automatically puts new content on a new line.
