### PR TITLE
Use ifconfig on guest machine to get any extra IPs available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This ip and the hostname will be used for the entry in the /etc/hosts file.
 
 ##  Versions
 
+### 0.0.12
+* Feature: Add support for private network dhcp
+
 ### 0.0.11
 * bugfix: Fix additional new lines being added to hosts file (Thanks to vincentmac)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ By setting the remove\_on\_suspend option, you can have them removed on **suspen
 
 ## Installation
 
-    $ vagrant plugin install vagrant-hostsupdater
+    $ gem install rake # If rake isn't already installed
+    $ git clone https://github.com/ben-rosio/vagrant-hostsupdater.git
+    $ cd vagrant-hostsupdater
+    $ rake build
+    $ vagrant plugin install pkg/vagrant-hostsupdater-0.0.12.gem
 
 Uninstall it with:
 
@@ -23,11 +27,11 @@ Uninstall it with:
 
 At the moment, the only things you need, are the hostname and a :private_network network with a fixed ip.
 
-    config.vm.network :private_network, ip: "192.168.3.10"
+    config.vm.network :private_network, type: :dhcp
     config.vm.hostname = "www.testing.de"
     config.hostsupdater.aliases = ["alias.testing.de", "alias2.somedomain.com"]
 
-This ip and the hostname will be used for the entry in the /etc/hosts file.
+An IP gotten from DHCP and the hostname will be used for the entry in the /etc/hosts file.
 
 ##  Versions
 

--- a/lib/vagrant-hostsupdater/version.rb
+++ b/lib/vagrant-hostsupdater/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module HostsUpdater
-    VERSION = "0.0.11"
+    VERSION = "0.0.12"
   end
 end


### PR DESCRIPTION
This came about when I was attempting to use a private network with type dhcp.  No host manager I've found supports this (as supporting it is a bit weird).

I went ahead and added the code to easily support it, but it could use some work, which I wouldn't mind doing when I have a bit more time.

It works by connecting to the machine, running `ifconfig`, and parsing out all the inet addresses.  It then loops through them, excluding the first (which is put in for Vagrant, if I understand correctly) and localhost.  It'll add them to the list of ips returned if they aren't already in it.

This allows dhcp private networks, which is really nice (so now you never have to know the ip, just your host name).

Example configuration:

```
config.vm.hostname = "devel.localhost"
config.vm.network :private_network, type: :dhcp
```
