### PR TITLE
Windows cmd scripts to change hosts permissions

### DIFF
--- a/cmd/win-hosts-check.cmd
+++ b/cmd/win-hosts-check.cmd
@@ -1,0 +1,46 @@
+@ECHO off
+SETLOCAL ENABLEEXTENSIONS
+REM modify hosts access rights current user can change the file contents
+
+call :hostfileperms _perms
+echo Permissins on hosts for user %USERNAME%: %_perms%
+
+If "%_perms%" == "F"    goto :PERM_OK
+If "%_perms%" == "M"    goto :PERM_OK
+If "%_perms%" == "RX,W" goto :PERM_OK
+If "%_perms%" == "R,W"  goto :PERM_OK
+If "%_perms%" == "W"    goto :PERM_OK
+
+If "%_perms%" == ":"    goto :PERM_INSUFFICIENT
+If "%_perms%" == "R"    goto :PERM_INSUFFICIENT
+If "%_perms%" == "RX"   goto :PERM_INSUFFICIENT
+
+echo Unhandled "%_perms%", raising.
+goto :PERM_INSUFFICIENT
+
+:PERM_INSUFFICIENT
+echo|set /p=Raising permissions...
+call win-hosts-set.cmd
+echo|set /p=done.
+call :hostfileperms _perms_new
+echo  New permissins are: %_perms_new%
+IF "%_perms%" == "%_perms_new%" (
+    echo Changing permissions failed. Exiting.
+    exit /b 1
+)
+
+:PERM_OK
+echo Suffice. Exiting.
+goto :EOF
+
+:hostfileperms
+setlocal
+set _icacls_cmd=Icacls %SystemRoot%\system32\drivers\etc\hosts /T
+FOR /f "tokens=2" %%G IN ('%_icacls_cmd% ^|find "%USERNAME%"') DO set _permission_info=%%G
+set "_permission_perms=%_permission_info:*:=%"
+set _permission=%_permission_perms:~1,-1%
+
+( endlocal
+  set "%1=%_permission%"
+)
+exit /b

--- a/cmd/win-hosts-set.cmd
+++ b/cmd/win-hosts-set.cmd
@@ -1,0 +1,13 @@
+@if (1==1) @if(1==0) @ELSE
+@echo off&SETLOCAL ENABLEEXTENSIONS
+>nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"||(
+    cscript //E:JScript //nologo "%~f0"
+    @goto :EOF
+)
+CACLS %SystemRoot%\system32\drivers\etc\hosts /E /G %USERNAME%:W
+@goto :EOF
+@end @ELSE
+ShA=new ActiveXObject("Shell.Application")
+ShA.ShellExecute("cmd.exe","/c \""+WScript.ScriptFullName+"\"","","runas",5);
+WScript.Sleep(500)
+@end


### PR DESCRIPTION
I created two windows cmd scripts that can work together to change permissions for
the current user to modify the hosts file.

the first script `win-hosts-check.cmd` checks if the permissions on the file are sufficient. It can be called from it's directory.

If not it will call the second script `win-hosts-set.cmd` which will trigger the windows
permission dialog asking for enough rights to modify the permissions on
the hosts file for the current user.

See issue #40

Note 1: As those are supporting files I didin't know where to place them. So I create the `cmd` subdirectory. I don't know the correct convetions for those vagrant plugins with those.

Note 2: The principle on linux if the permissions are not enough is to sudo out a sed command. Those two script are not aligned with such a principle. Instead those work idempotent and the first script only needs to be called as it will take care to set permissions only if necessary.
