### PR TITLE
Add all aliases, regardless of the IP

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -76,14 +76,13 @@ module VagrantPlugins
 
       def addHostEntries
         ips = getIps
-        hostnames = getHostnames(ips)
         file = File.open(@@hosts_path, "rb")
         hostsContents = file.read
         uuid = @machine.id
         name = @machine.name
         entries = []
-        ips.each do |ip|
-          hostnames[ip].each do |hostname|
+        getHostnames(ips).each do |ip, hostnames|
+          hostnames.each do |hostname|
             entryPattern = hostEntryPattern(ip, hostname)
 
             if hostsContents.match(/#{entryPattern}/)


### PR DESCRIPTION
Previously, only aliases for IPs that had been previously captured in network config in Vagrantfile were added. From now on, all the hash map of aliases is added regardless of the IP.
For example, if a machine had private network configured (for example, with IP 192.168.33.10), and map of aliases such as the following was provided, alias for 127.0.0.1, which wasn't directly mentioned in Vagrantfile, was omitted: 
```
config.hostsupdater.aliases = {
    '192.168.33.10' => ['example.org'],
    '127.0.0.1' => ['external.example.org'],
}
```

This pull request traverses through all the items in the hash map with aliases, and adds all of them, regardless of the ip, which seems more natural for the case when hash map is provided.