### PR TITLE
Resolves #198: Fix plugin operability while working with a multi-machine Vagrantfile

### DIFF
--- a/lib/vagrant-hostsupdater/Action/BaseAction.rb
+++ b/lib/vagrant-hostsupdater/Action/BaseAction.rb
@@ -21,9 +21,14 @@ module VagrantPlugins
         end
 
         def call(env)
-          if not @@completed.key?(self.class.name)
+          # Check whether the plugin has been executed for a particular
+          # VM as it may happen that a single Vagrantfile defines multiple
+          # machines and having a static flag will result in a plugin being
+          # executed just once.
+          # https://github.com/agiledivider/vagrant-hostsupdater/issues/198
+          if not @@completed.key?(@machine.name)
             run(env)
-            @@completed[self.class.name] = true
+            @@completed[@machine.name] = true
           end
 
           @app.call(env)


### PR DESCRIPTION
Addresses #198 that disclosed a regression after #197.

Patch 1.2.2:

```bash
cd ~/.vagrant.d/gems/<VERSION>/gems/vagrant-hostsupdater-1.2.2
curl -sSL https://github.com/agiledivider/vagrant-hostsupdater/pull/199.patch -o 199.patch
patch -p1 < 199.patch
```