### PR TITLE
Resolves #200

### DIFF
--- a/lib/vagrant-hostsupdater/Action/BaseAction.rb
+++ b/lib/vagrant-hostsupdater/Action/BaseAction.rb
@@ -26,9 +26,9 @@ module VagrantPlugins
           # machines and having a static flag will result in a plugin being
           # executed just once.
           # https://github.com/agiledivider/vagrant-hostsupdater/issues/198
-          if not @@completed.key?(@machine.name)
+          if @machine.id and not @@completed.key?("#{self.class.name}-#{@machine.name}")
             run(env)
-            @@completed[@machine.name] = true
+            @@completed["#{self.class.name}-#{@machine.name}"] = true
           end
 
           @app.call(env)

--- a/lib/vagrant-hostsupdater/Action/RemoveHosts.rb
+++ b/lib/vagrant-hostsupdater/Action/RemoveHosts.rb
@@ -5,15 +5,16 @@ module VagrantPlugins
 
         def run(env)
           machine_action = env[:machine_action]
-          if machine_action != :destroy || !@machine.id
-            if machine_action != :suspend || false != @machine.config.hostsupdater.remove_on_suspend
-              if machine_action != :halt || false != @machine.config.hostsupdater.remove_on_suspend
-                @ui.info "[vagrant-hostsupdater] Removing hosts"
-                removeHostEntries
-              else
-                @ui.info "[vagrant-hostsupdater] Removing hosts on suspend disabled"
-              end
+          if [:suspend, :halt].include? machine_action
+            if @machine.config.hostsupdater.remove_on_suspend == false
+              @ui.info "[vagrant-hostsupdater] Not removing hosts (remove_on_suspend false)"
+            else
+              @ui.info "[vagrant-hostsupdater] Removing hosts on suspend"
+              removeHostEntries
             end
+          else
+            @ui.info "[vagrant-hostsupdater] Removing hosts"
+            removeHostEntries
           end
         end
 


### PR DESCRIPTION
Fixes bugs caused by not having machine.id on first call to initialize().
Also allows each plugin to be called once instead of only one plugin per machine.