### PR TITLE
[fix] #195 No entries written to C:/Windows/system32/drivers/etc/hosts

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -145,15 +145,6 @@ module VagrantPlugins
             @ui.error "[vagrant-hostsupdater] Failed to add hosts, could not use sudo"
             adviseOnSudo
           end
-        elsif Vagrant::Util::Platform.windows?
-          require 'tmpdir'
-          uuid = @machine.id || @machine.config.hostsupdater.id
-          tmpPath = File.join(Dir.tmpdir, 'hosts-' + uuid.to_s + '.cmd')
-          File.open(tmpPath, "w") do |tmpFile|
-          entries.each { |line| tmpFile.puts(">>\"#{@@hosts_path}\" echo #{line}") }
-          end
-          sudo(tmpPath)
-          File.delete(tmpPath)
         else
           content = "\n" + content + "\n"
           hostsFile = File.open(@@hosts_path, "a")


### PR DESCRIPTION
It's code generate invalid cmd file like: 
```batch 
>>"C:/Windows/system32/drivers/etc/hosts" echo 192.168.100.10  lesson1  # ...
```
which is not needed because we have already checked the write permissions on the line: 
119: `if !File.writable_real?(@@hosts_path)`